### PR TITLE
fix a minor issue of rosa provision

### DIFF
--- a/common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
+++ b/common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
@@ -89,7 +89,7 @@ spec:
               max_retries=25
               # if the operator is not available, wait 60s and check again
               while [ "$retries" -lt "$max_retries" ]; do
-                  available=$(kubectl get co "$operator" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}')
+                  available=$(kubectl get co "$operator" -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' || echo "False")
                   if [ "$available" == "True" ]; then
                       break
                   fi
@@ -120,6 +120,11 @@ spec:
                 echo "Failed to get the HCP full version of $OCP_VERSION" >&2
                 exit 1
             fi
+        }
+
+        # Function to check if the API server is ready
+        check_api_server() {
+          kubectl get nodes >/dev/null 2>/dev/null || true
         }
 
         deploy_cluster() {
@@ -174,9 +179,22 @@ spec:
 
             #Workaround: Check if apiserver is ready by calling kubectl get nodes
             printf "INFO: Check if apiserver is ready...\n"
-            if ! timeout 300s bash -c "while ! kubectl get nodes >/dev/null 2>/dev/null; do printf '.'; sleep 10; done"; then
-                echo "ERROR: API server is not ready" >&2
-                exit 1
+            # Timeout loop to wait for the API server to be ready
+            timeout 300s bash -c '
+            while true; do
+              if check_api_server; then
+                echo "API server is ready"
+                exit 0
+              else
+                echo -n "."  # Print a dot to indicate progress
+                sleep 10
+              fi
+            done
+            '
+
+            if [ $? -ne 0 ]; then
+              echo "ERROR: API server is not ready" >&2
+              exit 1
             fi
             check_clusteroperators
         }


### PR DESCRIPTION
Sometimes it will fail with the following error, this PR is to make sure it won't break the whole process when api server host somehow is not available  .
```
[provision] INFO: Check if apiserver is ready...
[provision] Retried 1 times...
[provision] Unable to connect to the server: dial tcp: lookup api.kx-4298439a99.i7nt.p3.openshiftapps.com on 172.30.0.10:53: no such host

```