### PR TITLE
Remove unecessary parameters from collect-artifacts-deprovision-rosa

### DIFF
--- a/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+++ b/common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
@@ -20,21 +20,6 @@ spec:
     - name: oci-container
       type: string
       description: The ORAS container registry URI where artifacts will be stored.
-    - name: pull-request-author
-      type: string
-      description: The GitHub username of the author of the pull request.
-    - name: git-revision
-      type: string
-      description: The Git revision (commit SHA) for the current build.
-    - name: pull-request-number
-      type: string
-      description: The number of the GitHub pull request.
-    - name: git-repo
-      type: string
-      description: The name of the GitHub repository where the pull request was made.
-    - name: git-org
-      type: string
-      description: The GitHub organization or user that owns the repository.
     - name: cluster-name
       type: string
       description: The name of the OpenShift cluster that is to be deleted.


### PR DESCRIPTION
Code requiring these parameters disappeared long time ago: https://github.com/konflux-ci/konflux-qe-definitions/commit/d64b77195f7605d7d48f15458871f6f6f4af0015#diff-0ef56e22bed55502a8f9219c48e9242cbef41f68fac5f22f89d0a5ac5571e81b