### PR TITLE
fix: change the author in retest for konflux updates prs

### DIFF
--- a/common/tasks/test-metadata/0.2/test-metadata.yaml
+++ b/common/tasks/test-metadata/0.2/test-metadata.yaml
@@ -40,10 +40,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['pac.test.appstudio.openshift.io/url-repository']
-        - name: PR_AUTHOR
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sender']
         - name: SOURCE_REPO_URL
           valueFrom:
             fieldRef:
@@ -59,6 +55,8 @@ spec:
         GIT_URL=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .source.git.url' <<< "$SNAPSHOT")
         GIT_REVISION=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .source.git.revision' <<< "$SNAPSHOT")
         SOURCE_REPO_ORG=$(echo "$SOURCE_REPO_URL" | sed -E 's#https://github.com/([^/]+)/.*#\1#')
+
+        PR_AUTHOR="$(curl -s https://api.github.com/repos/${GIT_ORGANIZATION}/${GIT_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER} | jq -r .user.login)"
 
         COMPONENT_CONTAINER_IMAGE=$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")
 


### PR DESCRIPTION
This is the [PR](https://github.com/konflux-ci/release-service-catalog/pull/657/files)  which is using the "pull-request-author".